### PR TITLE
Fix Page Load Jumps

### DIFF
--- a/wp-content/themes/manor/js/custom-functions.js
+++ b/wp-content/themes/manor/js/custom-functions.js
@@ -1,8 +1,42 @@
-jQuery(window).load(function() {
-   
-   if( jQuery('body.home').length == 0 ){
+var NEGATIVE_SCROLL_OFFSET = 50; // pixels we want to start off scrolled above the Title
+var TMP_CONTENT_HEIGHT = 4000; // pixels the content section should start out at temporarily
 
-        var item1 = jQuery( ".site-title" )[ 0 ];
-        jQuery(('html, body')).scrollTop(jQuery(item1).offset().top - 30);
-   }
+var $ = jQuery;
+var $content = $('#site-content');
+
+/**
+ * Set the scroll position to just above the title for any page that isn't the home page. This removes the need to
+ * scroll past the header image every time the visitor changes pages.
+ */
+var setScrollPosition = function () {
+    // @todo someday we could save the last scroll position in localStorage or a URL param
+    var $title = $('.site-title');
+    $('html, body').scrollTop($title.offset().top - NEGATIVE_SCROLL_OFFSET);
+};
+
+/**
+ * We need to make sure the window is tall enough to scroll down
+ */
+var expandContentSection = function () {
+    $content.css('height', TMP_CONTENT_HEIGHT); // temporarily set this to be super high so we know our scroll position will be valid
+};
+
+/**
+ * We can undo our temporary changes once everything has loaded.
+ */
+var restoreContentSection = function () {
+    $content.css('height', '');
+};
+
+$(document).ready(function () {
+    if ($('body').hasClass('home')) {
+        return;
+    }
+
+    // As page is loading, set scroll position
+    expandContentSection();
+    setScrollPosition();
+
+    // When page finishes loading, undo temporary changes
+    $(window).on('load', restoreContentSectionn);
 });


### PR DESCRIPTION
This is my attempt to fix the scroll jump that happens when loading any of the non-home pages (caused by https://github.com/rwarner/warnerdiscovers-wordpress/commit/e28fd361256195107a5e3ddfc520f118738d871b).

⚠️ Keep in mind that I'm not fully able to test this since I don't have access to your Wordpress instance.

Here's how this works:

1. Script runs inside `$(document).ready()` after the initial DOM has been drawn to the page.
1. It sets a temporary height of `<div id="site-content">` to an arbitrary 4000px. This ensures that wherever we want to scroll to is available (i.e., the page is long enough to have a scrollbar and scroll to the point we want to).
1. We scroll to just above the Title (as was already happening).
1. When the rest of the page loads (posts are loaded), we remove the temporary height. This will make it dynamic again so that it wraps whatever content has been loaded into it.

Again, I can't prove that this 100% works, but hopefully it's an improvement 🤞 Alternatively, you could maybe avoid all of this by setting a secondary header image for all non-home pages that isn't so tall.